### PR TITLE
Updates Default Listen Address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Main configuration
 httpd_ServerRoot: '/etc/httpd'
 httpd_Listen: 80
+httpd_ServerName: "{{ ansible_default_ipv4.address }}"
 httpd_ServerAdmin: root@localhost
 httpd_ServerTokens: Prod
 httpd_DocumentRoot: '/var/www/html'


### PR DESCRIPTION
Previously, the default listen address was loopback. The ansible
ipv4 addr is a better default as the server should listen on a
network interface ip.